### PR TITLE
Use "dependsOn" for hard Go dependency

### DIFF
--- a/devcontainer-feature.json
+++ b/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Tiny Go (no sudo)",
     "id": "tinygo",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A feature to install tiny go (no sudo)",
     "options": {
         "version": {
@@ -10,19 +10,15 @@
             "description": "Specify a version of Tiny Go"
         }
     },
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/rust",
-        "cargo_binstall"
-    ],
+    "dependsOn": {
+        "ghcr.io/devcontainers/features/go": {}
+    },
     "customizations": {
         "vscode": {
             "extensions": [
                 "tinygo.vscode-tinygo",
                 "golang.go"
-            ],
-            "features": {
-                "ghcr.io/devcontainers/features/go:1": {}
-            }
+            ]
         }
     }
 }


### PR DESCRIPTION
> You must have Go already installed on your machine in order to install TinyGo. We recommend Go v1.18 or above.

&mdash; https://tinygo.org/getting-started/install/linux/

there's this cool thing: https://github.com/devcontainers/spec/blob/main/proposals/feature-dependencies.md

and its in the main spec: https://github.com/devcontainers/spec/pull/292

and its in the reference cli: https://github.com/devcontainers/cli/pull/530

this pr would:
- change customizations.vscode.features to .dependsOn
- remove the installsAfter: rust, cargo_binstall