### PR TITLE
Add documentationURL

### DIFF
--- a/devcontainer-feature.json
+++ b/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Tiny Go (no sudo)",
     "id": "tinygo",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A feature to install tiny go (no sudo)",
     "documentationURL": "https://github.com/devcontainers-community/features-tinygo#readme",
     "options": {

--- a/devcontainer-feature.json
+++ b/devcontainer-feature.json
@@ -3,6 +3,7 @@
     "id": "tinygo",
     "version": "1.0.0",
     "description": "A feature to install tiny go (no sudo)",
+    "documentationURL": "https://github.com/devcontainers-community/features-tinygo#readme",
     "options": {
         "version": {
             "type": "string",


### PR DESCRIPTION
makes it so that there'll be a link on the index page:
![image](https://github.com/devcontainers-community/features-tinygo/assets/61068799/7e8109ec-c321-4fbd-9718-ed560a6d5f64)
https://github.com/devcontainers-community/features

also i think the documentationURL is surfaced in error messages like "oh no error! check ${documentationURL} for help" when a feature errors